### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,11 @@ by declaring a new class with its fields.
     :target: https://coveralls.io/r/Jokymon/binstruct?branch=master
     :alt: Test coverage
 
-.. image:: https://pypip.in/version/binstruct/badge.svg
+.. image:: https://img.shields.io/pypi/v/binstruct.svg
     :target: https://pypi.python.org/pypi/binstruct/
     :alt: PyPI version
 
-.. image:: https://pypip.in/py_versions/binstruct/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/binstruct.svg
     :target: https://pypi.python.org/pypi/binstruct/
     :alt: Supported Python versions
 
@@ -28,11 +28,11 @@ by declaring a new class with its fields.
     :target: https://pypi.python.org/pypi/binstruct/
     :alt: Egg Status
 
-.. image:: https://pypip.in/wheel/binstruct/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/binstruct.svg
     :target: https://pypi.python.org/pypi/binstruct/
     :alt: Wheel Status
 
-.. image:: https://pypip.in/license/binstruct/badge.svg
+.. image:: https://img.shields.io/pypi/l/binstruct.svg
     :target: https://pypi.python.org/pypi/binstruct/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20binstruct))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `binstruct`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.